### PR TITLE
Update cordova-plugin-add-swift-support version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/GEDYSIntraWare/cordova-plugin-call-directory#readme",
   "dependencies": {
-    "cordova-plugin-add-swift-support": "^1.7.1",
+    "cordova-plugin-add-swift-support": "^2.0.0",
     "elementtree": "^0.1.7",
     "file-system": "^2.2.2",
     "path": "^0.12.7",

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
   <!-- ios -->
   <platform name="ios">
-    <dependency id="cordova-plugin-add-swift-support" version="^1.7.0"/>
+    <dependency id="cordova-plugin-add-swift-support" version="^2.0.0"/>
     <config-file target="config.xml" parent="/*">
       <feature name="CallDirectory">
         <param name="ios-package" value="CallDirectory"/>


### PR DESCRIPTION
Updates the required version of cordova-plugin-add-swift-support to ^2.0.0, for the fixes included in the plugin for Cordova CLI 9.x.